### PR TITLE
[cron-manager] fix missing ts-node-dev 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./cron-manager:/usr/src/app
+      - /usr/src/app/node_modules
 
 
 volumes:


### PR DESCRIPTION
define volume for copying between builder container and main