### PR TITLE
Update default branch for javascript catcher

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,7 +13,7 @@
 [submodule "hawk.javascript"]
 	path = catchers/javascript
 	url = https://github.com/codex-team/hawk.javascript
-	branch = hawk2.0
+	branch = master
 [submodule "collector"]
 	path = collector
 	url = https://github.com/codex-team/hawk.collector


### PR DESCRIPTION
Since for javascript catcher the default branch is master (not hawk2.0)