### PR TITLE
[Fix] Fix mongo restore scripts on windows

### DIFF
--- a/mongorestore-accounts.sh
+++ b/mongorestore-accounts.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose exec -T mongodb mongorestore --host mongodb --drop -d hawk /dump/hawk_accounts
+docker-compose exec -T mongodb mongorestore --host mongodb --drop -d hawk ./dump/hawk_accounts

--- a/mongorestore-events.sh
+++ b/mongorestore-events.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose exec -T mongodb mongorestore --host mongodb --drop -d hawk_events /dump/hawk_events
+docker-compose exec -T mongodb mongorestore --host mongodb --drop -d hawk_events ./dump/hawk_events


### PR DESCRIPTION
Bug:
![image](https://user-images.githubusercontent.com/37909603/97032730-f1a87d80-156a-11eb-9baa-1f4303b99c75.png)

Uses relative paths in mongorestore scripts.