### PR TITLE
[Feature] Remove deps in garage service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,6 @@ services:
       - /app/node_modules
     ports:
       - 8080:8080
-    depends_on:
-      - api
 
   rabbitmq:
     image: rabbitmq:3-management


### PR DESCRIPTION
I use garage with production api, but docker compose always runs api on local. I removed api from deps.